### PR TITLE
Security - Bump @xmldom/xmldom to patched 0.7.6

### DIFF
--- a/packages/spa-sdk/package.json
+++ b/packages/spa-sdk/package.json
@@ -87,7 +87,7 @@
     "typescript": "4.1.6"
   },
   "dependencies": {
-    "@xmldom/xmldom": "0.7.2",
+    "@xmldom/xmldom": "0.7.6",
     "cookie": "0.4.1",
     "emittery": "0.7.2",
     "inversify": "5.1.1",


### PR DESCRIPTION
Resolves the following critical security vulnerability found in `@xmldom/xmldom` @ `<0.7.6`: https://github.com/advisories/GHSA-9pgh-qqpf-7wqj

## npm audit

```
$ spa-sdk git:(main) npm audit
# npm audit report

@xmldom/xmldom  <0.7.6
Severity: critical
Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution') in @xmldom/xmldom and xmldom - https://github.com/advisories/GHSA-9pgh-qqpf-7wqj
fix available via `npm audit fix --force`
Will install @xmldom/xmldom@0.7.6, which is outside the stated dependency range
node_modules/@xmldom/xmldom
...
```