### PR TITLE
Refactor BrPage Component in Bloomreach React SDK

### DIFF
--- a/packages/react-sdk/package-lock.json
+++ b/packages/react-sdk/package-lock.json
@@ -31,6 +31,7 @@
         "jest-junit": "13.2.0",
         "prop-types": "15.8.1",
         "react": "18.2.0",
+        "react-error-boundary": "^4.0.13",
         "rollup": "2.55.0",
         "rollup-plugin-dts": "3.0.2",
         "rollup-plugin-terser": "7.0.2",
@@ -44,7 +45,7 @@
       }
     },
     ".yalc/@bloomreach/spa-sdk": {
-      "version": "22.0.2",
+      "version": "22.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "cookie": "0.4.1",
@@ -9640,6 +9641,18 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-error-boundary": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-4.0.13.tgz",
+      "integrity": "sha512-b6PwbdSv8XeOSYvjt8LpgpKrZ0yGdtZokYwkwV2wlcZbxgopHX/hgPl5VgpnoVOWd868n1hktM8Qm4b+02MiLQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
       }
     },
     "node_modules/react-is": {

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -65,6 +65,7 @@
     "jest-junit": "13.2.0",
     "prop-types": "15.8.1",
     "react": "18.2.0",
+    "react-error-boundary": "^4.0.13",
     "rollup": "2.55.0",
     "rollup-plugin-dts": "3.0.2",
     "rollup-plugin-terser": "7.0.2",

--- a/packages/react-sdk/src/page/BrPage.spec.tsx
+++ b/packages/react-sdk/src/page/BrPage.spec.tsx
@@ -213,6 +213,7 @@ describe('BrPage', () => {
 
       function MyComponent(): JSX.Element {
         useEffect(() => someEffect());
+        // eslint-disable-next-line react/jsx-no-useless-fragment
         return <></>;
       }
 

--- a/packages/react-sdk/src/page/BrPage.tsx
+++ b/packages/react-sdk/src/page/BrPage.tsx
@@ -52,6 +52,7 @@ interface BrPageProps {
  */
 export function BrPage(props: React.PropsWithChildren<BrPageProps>): JSX.Element | null {
   const { page, configuration, mapping, children } = props;
+  // eslint-disable-next-line max-len
   const pageDerivedFromProps = React.useMemo<Page | undefined>(() => page && initialize(configuration, page), [page, configuration]);
   const [pageInState, setPageInState] = React.useState<Page | undefined>(pageDerivedFromProps);
 
@@ -70,6 +71,7 @@ export function BrPage(props: React.PropsWithChildren<BrPageProps>): JSX.Element
     } else if (pageInState !== pageDerivedFromProps) {
       setPageInState(pageDerivedFromProps);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pageDerivedFromProps]);
 
   React.useEffect(() => {

--- a/packages/react-sdk/src/page/__snapshots__/BrPage.spec.tsx.snap
+++ b/packages/react-sdk/src/page/__snapshots__/BrPage.spec.tsx.snap
@@ -13,3 +13,11 @@ exports[`BrPage render should render children if there is no page and NBR mode i
   <div />
 </DocumentFragment>
 `;
+
+exports[`BrPage render should render nothing if there is an error loading the page 1`] = `
+<DocumentFragment>
+  <div>
+    fallback
+  </div>
+</DocumentFragment>
+`;


### PR DESCRIPTION
Hi,

This PR tries to refactor the code for BrPage in @bloomreach/react-sdk with the following aims:
- BrPage becomes a function component in line with the recommendation from React
- The code becomes a bit simpler and easier to maintain, for instance avoiding calling `destroy` and re-`sync` if only the configuration in props has changed, but page in props hasn't changed
- May be a starting point for further refactoring of BrPage so that it better fits the development in React...

This is my first commit to this repo, and comments are very welcome! ☺️ 